### PR TITLE
cbPerObject's comment => "per object"

### DIFF
--- a/Chapter 21 Ambient Occlusion/Ssao/Shaders/Common.hlsl
+++ b/Chapter 21 Ambient Occlusion/Ssao/Shaders/Common.hlsl
@@ -51,7 +51,7 @@ SamplerState gsamAnisotropicWrap  : register(s4);
 SamplerState gsamAnisotropicClamp : register(s5);
 SamplerComparisonState gsamShadow : register(s6);
 
-// Constant data that varies per frame.
+// Constant data that varies per object.
 cbuffer cbPerObject : register(b0)
 {
     float4x4 gWorld;


### PR DESCRIPTION
cbPerObject's comment is supposed to say "per object" instead of "per frame".