### PR TITLE
Remove redundant BuildRenderItems() call

### DIFF
--- a/Chapter 7 Drawing in Direct3D Part II/LandAndWaves/LandAndWavesApp.cpp
+++ b/Chapter 7 Drawing in Direct3D Part II/LandAndWaves/LandAndWavesApp.cpp
@@ -184,7 +184,6 @@ bool LandAndWavesApp::Initialize()
 	BuildLandGeometry();
     BuildWavesGeometryBuffers();
     BuildRenderItems();
-	BuildRenderItems();
     BuildFrameResources();
 	BuildPSOs();
 


### PR DESCRIPTION
Hello, 

There is a redundant `BuildRenderItems()` call in Chapter 7's demo code. 

Best,
Zixin